### PR TITLE
[doc] az aks nodepool update --node-taints

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -1563,7 +1563,7 @@ parameters:
     short-summary: Extra nodes used to speed upgrade. When specified, it represents the number or percent used, eg. 5 or 33%
   - name: --node-taints
     type: string
-    short-summary: The node taints for the node pool. You can update the existing node taint of a nodepool or create a new node taint for a nodepool. Pass the empty string `""` to remove all taints.
+    short-summary: The node taints for the node pool. You can update the existing node taint of a nodepool or create a new node taint for a nodepool. Pass the empty string `""` (or `'""'` in PowerShell) to remove all taints.
   - name: --labels
     type: string
     short-summary: The node labels for the node pool. See https://aka.ms/node-labels for syntax of labels.


### PR DESCRIPTION
remove --node-taints in powershell does not work if you do not escape the double quotes

**Related command**
az aks nodepool update --node-taints

**Description**<!--Mandatory-->
The provided example does not work in PowerShell and the error is confusing.

**Testing Guide**
![image](https://github.com/MaxMelcher/azure-cli/assets/1029559/3399e6f8-5cea-4f46-8a61-b7af5459d0df)

az aks nodepool update --resource-group <rg>--cluster-name <cluster> --name <nodepool> --node-taints ""
results in: argument --node-taints: expected one argument


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
